### PR TITLE
chore: reuse or pin local Actions + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Convert chart `yaml-lint.yml` workflows that used floating `karancode/yamllint-github-action` to `actionsforge` `yaml-lint` reusable
- SHA-pin remaining floating marketplace actions (e.g. kube-platform-apps validators)
- Keep pip-based yaml-lint where karancode is intentionally avoided
- Add Dependabot for `github-actions` when missing

## Test plan
- [ ] Required workflow checks pass